### PR TITLE
Added additional text to the Help Desk Widget

### DIFF
--- a/index.php
+++ b/index.php
@@ -69,7 +69,7 @@ class it_services_spiceWorks extends WP_Widget {
 	function __construct() {
 		parent::__construct(
 			'it_services', // Base ID
-			__('IT Services - Spice Works', 'text_domain'), // Name
+			__('IT Services - Help Desk', 'text_domain'), // Name
 			array( 'description' => __( 'Adds a graphic widget for linking to SpiceWorks', 'text_domain' ), ) // Args
 		);
 	}


### PR DESCRIPTION
e595e74 fixes #17.

 0d6092f was added for clarity in the WordPress admin since originally the widget was supposed to be an interface for Spice Works.
